### PR TITLE
Corrects typo 'occured' into 'occurred'.

### DIFF
--- a/src/collections/nodeset.rs
+++ b/src/collections/nodeset.rs
@@ -426,7 +426,7 @@ pub enum ConfigurationError {
 /// Errors that may happen when parsing nodesets
 #[derive(thiserror::Error, Debug)]
 pub enum NodeSetParseError {
-    /// An error occured while parsing an integer.
+    /// An error occurred while parsing an integer.
     #[error("invalid integer")]
     ParseIntError(#[from] std::num::ParseIntError),
 


### PR DESCRIPTION
Corrects a documentation typo (occured -> occurred).