### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.6.0](https://github.com/fdiakh/nodeset-rs/compare/v0.5.0...v0.6.0) - 2025-11-09
+
+### Added
+
+- add a basic C API to handle nodesets
+
+### Fixed
+
+- remove unnecessary debug log
+- make NodeSetIter pub
+- replace unmaintained dependency
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "nodeset"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "auto_enums",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nodeset"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Francois Diakhate <fdiakh@gmail.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION


## 🤖 New release

* `nodeset`: 0.5.0 -> 0.6.0
  * ✓ API compatible changes
  * MSRV bumped to 1.82
<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.0](https://github.com/fdiakh/nodeset-rs/compare/v0.5.0...v0.6.0) - 2025-11-09

### Added

- add a basic C API to handle nodesets

### Fixed

- remove unnecessary debug log
- make NodeSetIter pub
- replace unmaintained dependency
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).